### PR TITLE
Add Flutter web sample with BLoC

### DIFF
--- a/animal_info_app/README.md
+++ b/animal_info_app/README.md
@@ -1,0 +1,4 @@
+# Animal Info App
+
+A simple Flutter web app demonstrating a splash screen, a home page with navigation
+to login or information pages, and a login form implemented with the BLoC pattern.

--- a/animal_info_app/lib/bloc/login_bloc.dart
+++ b/animal_info_app/lib/bloc/login_bloc.dart
@@ -1,0 +1,21 @@
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'login_event.dart';
+import 'login_state.dart';
+
+class LoginBloc extends Bloc<LoginEvent, LoginState> {
+  LoginBloc() : super(const LoginState()) {
+    on<UsernameChanged>((event, emit) {
+      emit(state.copyWith(username: event.username));
+    });
+    on<PasswordChanged>((event, emit) {
+      emit(state.copyWith(password: event.password));
+    });
+    on<LoginReset>((event, emit) {
+      emit(const LoginState());
+    });
+    on<LoginSubmitted>((event, emit) {
+      // In a real app you would add authentication logic here
+      emit(state); // no change
+    });
+  }
+}

--- a/animal_info_app/lib/bloc/login_event.dart
+++ b/animal_info_app/lib/bloc/login_event.dart
@@ -1,0 +1,28 @@
+import 'package:equatable/equatable.dart';
+
+abstract class LoginEvent extends Equatable {
+  const LoginEvent();
+
+  @override
+  List<Object?> get props => [];
+}
+
+class UsernameChanged extends LoginEvent {
+  final String username;
+  const UsernameChanged(this.username);
+
+  @override
+  List<Object?> get props => [username];
+}
+
+class PasswordChanged extends LoginEvent {
+  final String password;
+  const PasswordChanged(this.password);
+
+  @override
+  List<Object?> get props => [password];
+}
+
+class LoginSubmitted extends LoginEvent {}
+
+class LoginReset extends LoginEvent {}

--- a/animal_info_app/lib/bloc/login_state.dart
+++ b/animal_info_app/lib/bloc/login_state.dart
@@ -1,0 +1,18 @@
+import 'package:equatable/equatable.dart';
+
+class LoginState extends Equatable {
+  final String username;
+  final String password;
+
+  const LoginState({this.username = '', this.password = ''});
+
+  LoginState copyWith({String? username, String? password}) {
+    return LoginState(
+      username: username ?? this.username,
+      password: password ?? this.password,
+    );
+  }
+
+  @override
+  List<Object?> get props => [username, password];
+}

--- a/animal_info_app/lib/main.dart
+++ b/animal_info_app/lib/main.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/material.dart';
+import 'pages/splash_page.dart';
+import 'pages/home_page.dart';
+import 'pages/login_page.dart';
+import 'pages/info_page.dart';
+
+void main() {
+  runApp(const AnimalInfoApp());
+}
+
+class AnimalInfoApp extends StatelessWidget {
+  const AnimalInfoApp({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Animal Info App',
+      routes: {
+        '/': (context) => const SplashPage(),
+        '/home': (context) => const HomePage(),
+        '/login': (context) => const LoginPage(),
+        '/info': (context) => const InfoPage(),
+      },
+      initialRoute: '/',
+    );
+  }
+}

--- a/animal_info_app/lib/pages/home_page.dart
+++ b/animal_info_app/lib/pages/home_page.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/material.dart';
+
+class HomePage extends StatelessWidget {
+  const HomePage({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Home')),
+      body: Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            ElevatedButton(
+              onPressed: () => Navigator.of(context).pushNamed('/login'),
+              child: const Text('Login'),
+            ),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: () => Navigator.of(context).pushNamed('/info'),
+              child: const Text('See Info'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/animal_info_app/lib/pages/info_page.dart
+++ b/animal_info_app/lib/pages/info_page.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/material.dart';
+
+class InfoPage extends StatelessWidget {
+  const InfoPage({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final articles = List.generate(10, (index) => 'Article #$index');
+    return Scaffold(
+      appBar: AppBar(title: const Text('Articles')),
+      body: ListView.builder(
+        itemCount: articles.length,
+        itemBuilder: (context, index) {
+          return ListTile(
+            title: Text(articles[index]),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/animal_info_app/lib/pages/login_page.dart
+++ b/animal_info_app/lib/pages/login_page.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import '../bloc/login_bloc.dart';
+import '../bloc/login_event.dart';
+import '../bloc/login_state.dart';
+
+class LoginPage extends StatelessWidget {
+  const LoginPage({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocProvider(
+      create: (_) => LoginBloc(),
+      child: Scaffold(
+        appBar: AppBar(title: const Text('Login')),
+        body: Padding(
+          padding: const EdgeInsets.all(16.0),
+          child: BlocBuilder<LoginBloc, LoginState>(
+            builder: (context, state) {
+              return Column(
+                children: [
+                  TextField(
+                    onChanged: (value) => context
+                        .read<LoginBloc>()
+                        .add(UsernameChanged(value)),
+                    decoration: const InputDecoration(labelText: 'Username'),
+                  ),
+                  TextField(
+                    onChanged: (value) => context
+                        .read<LoginBloc>()
+                        .add(PasswordChanged(value)),
+                    obscureText: true,
+                    decoration: const InputDecoration(labelText: 'Password'),
+                  ),
+                  const SizedBox(height: 16),
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                    children: [
+                      ElevatedButton(
+                        onPressed: () => context
+                            .read<LoginBloc>()
+                            .add(LoginSubmitted()),
+                        child: const Text('Login'),
+                      ),
+                      ElevatedButton(
+                        onPressed: () => context.read<LoginBloc>().add(LoginReset()),
+                        child: const Text('Reset'),
+                      ),
+                    ],
+                  ),
+                ],
+              );
+            },
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/animal_info_app/lib/pages/splash_page.dart
+++ b/animal_info_app/lib/pages/splash_page.dart
@@ -1,0 +1,29 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+
+class SplashPage extends StatefulWidget {
+  const SplashPage({Key? key}) : super(key: key);
+
+  @override
+  State<SplashPage> createState() => _SplashPageState();
+}
+
+class _SplashPageState extends State<SplashPage> {
+  @override
+  void initState() {
+    super.initState();
+    Timer(const Duration(seconds: 5), () {
+      Navigator.of(context).pushReplacementNamed('/home');
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Center(
+        child: Image.asset('assets/animal.png'),
+      ),
+    );
+  }
+}

--- a/animal_info_app/pubspec.yaml
+++ b/animal_info_app/pubspec.yaml
@@ -1,0 +1,17 @@
+name: animal_info_app
+publish_to: 'none'
+version: 1.0.0
+
+environment:
+  sdk: '>=2.19.0 <3.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+  flutter_bloc: ^8.1.1
+  equatable: ^2.0.3
+
+flutter:
+  uses-material-design: true
+  assets:
+    - assets/

--- a/animal_info_app/web/index.html
+++ b/animal_info_app/web/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <meta content="IE=Edge" http-equiv="X-UA-Compatible">
+  <meta name="description" content="Animal Info App">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Animal Info App</title>
+  <script src="main.dart.js" type="application/javascript"></script>
+</head>
+<body>
+  <script>window.flutterWebRenderer = 'html';</script>
+  <script src="flutter.js" defer></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a minimal Flutter web app using `flutter_bloc`
- include splash, home, login, and info pages
- implement login with BLoC state management

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68404c6b59708333b0235742a6eee7b0